### PR TITLE
Charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@generouted/react-router": "^1.15.1",
 		"@radix-ui/react-slot": "^1.0.2",
 		"@tanstack/react-table": "^8.9.3",
+		"echarts": "^5.4.3",
 		"file-saver": "^2.0.5",
 		"jszip": "^3.10.1",
 		"react": "^18.2.0",

--- a/src/assets/charts/dark.json
+++ b/src/assets/charts/dark.json
@@ -13,11 +13,11 @@
 	"categoryAxis": {
 		"axisLine": { "lineStyle": { "color": "#71717a" } },
 		"splitLine": { "lineStyle": { "color": "#71717a" } },
-		"axisLabel": { "textStyle": { "color": "#d4d4d8" } }
+		"axisLabel": { "color": "#d4d4d8" }
 	},
 	"valueAxis": {
 		"axisLine": { "lineStyle": { "color": "#71717a" } },
 		"splitLine": { "lineStyle": { "color": "#71717a" } },
-		"axisLabel": { "textStyle": { "color": "#d4d4d8" } }
+		"axisLabel": { "color": "#d4d4d8" }
 	}
 }

--- a/src/assets/charts/dark.json
+++ b/src/assets/charts/dark.json
@@ -1,0 +1,20 @@
+{
+	"title": {
+		"textStyle": { "color": "#f4f4f5" },
+		"subtextStyle": { "color": "#a1a1aa" }
+	},
+	"legend": {
+		"textStyle": { "color": "#f4f4f5" }
+	},
+	"label": { "color": "#d4d4d8" },
+	"categoryAxis": {
+		"axisLine": { "lineStyle": { "color": "#71717a" } },
+		"splitLine": { "lineStyle": { "color": "#71717a" } },
+		"axisLabel": { "textStyle": { "color": "#d4d4d8" } }
+	},
+	"valueAxis": {
+		"axisLine": { "lineStyle": { "color": "#71717a" } },
+		"splitLine": { "lineStyle": { "color": "#71717a" } },
+		"axisLabel": { "textStyle": { "color": "#d4d4d8" } }
+	}
+}

--- a/src/assets/charts/dark.json
+++ b/src/assets/charts/dark.json
@@ -6,6 +6,9 @@
 	"legend": {
 		"textStyle": { "color": "#f4f4f5" }
 	},
+	"visualMap": {
+		"textStyle": { "color": "#f4f4f5" }
+	},
 	"label": { "color": "#d4d4d8" },
 	"categoryAxis": {
 		"axisLine": { "lineStyle": { "color": "#71717a" } },

--- a/src/assets/charts/light.json
+++ b/src/assets/charts/light.json
@@ -6,6 +6,9 @@
 	"legend": {
 		"textStyle": { "color": "#18181b" }
 	},
+	"visualMap": {
+		"textStyle": { "color": "#18181b" }
+	},
 	"label": { "color": "#3f3f46" },
 	"categoryAxis": {
 		"axisLine": { "lineStyle": { "color": "#71717a" } },

--- a/src/assets/charts/light.json
+++ b/src/assets/charts/light.json
@@ -13,11 +13,11 @@
 	"categoryAxis": {
 		"axisLine": { "lineStyle": { "color": "#71717a" } },
 		"splitLine": { "lineStyle": { "color": "#71717a" } },
-		"axisLabel": { "textStyle": { "color": "#3f3f46" } }
+		"axisLabel": { "color": "#3f3f46" }
 	},
 	"valueAxis": {
 		"axisLine": { "lineStyle": { "color": "#71717a" } },
 		"splitLine": { "lineStyle": { "color": "#71717a" } },
-		"axisLabel": { "textStyle": { "color": "#3f3f46" } }
+		"axisLabel": { "color": "#3f3f46" }
 	}
 }

--- a/src/assets/charts/light.json
+++ b/src/assets/charts/light.json
@@ -1,0 +1,20 @@
+{
+	"title": {
+		"textStyle": { "color": "#18181b" },
+		"subtextStyle": { "color": "#52525b" }
+	},
+	"legend": {
+		"textStyle": { "color": "#18181b" }
+	},
+	"label": { "color": "#3f3f46" },
+	"categoryAxis": {
+		"axisLine": { "lineStyle": { "color": "#71717a" } },
+		"splitLine": { "lineStyle": { "color": "#71717a" } },
+		"axisLabel": { "textStyle": { "color": "#3f3f46" } }
+	},
+	"valueAxis": {
+		"axisLine": { "lineStyle": { "color": "#71717a" } },
+		"splitLine": { "lineStyle": { "color": "#71717a" } },
+		"axisLabel": { "textStyle": { "color": "#3f3f46" } }
+	}
+}

--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -1,0 +1,49 @@
+import { ECharts, EChartsOption, SetOptionOpts, getInstanceByDom, init } from "echarts";
+import { CSSProperties, useEffect, useRef } from "react";
+
+interface Props {
+	option: EChartsOption;
+	style?: CSSProperties;
+	settings?: SetOptionOpts;
+	show?: boolean;
+	loading?: boolean;
+	theme?: string;
+}
+
+export default function Chart({ option, style, settings, show = true, loading, theme }: Props): JSX.Element | null {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		let chart: ECharts | undefined;
+		if (ref.current !== null) {
+			chart = init(ref.current, theme);
+		}
+
+		function resizeChart() {
+			chart?.resize();
+		}
+		window.addEventListener("resize", resizeChart);
+
+		return () => {
+			chart?.dispose();
+			window.removeEventListener("resize", resizeChart);
+		};
+	}, [theme]);
+
+	useEffect(() => {
+		if (ref.current !== null) {
+			const chart = getInstanceByDom(ref.current);
+			chart!.setOption(option, settings);
+		}
+	}, [option, settings, theme]);
+
+	useEffect(() => {
+		if (ref.current !== null) {
+			const chart = getInstanceByDom(ref.current);
+			loading === true ? chart!.showLoading() : chart!.hideLoading();
+		}
+	}, [loading, theme]);
+
+	if (!show) return null;
+	return <div ref={ref} style={{ width: "100%", height: "100%", ...style }} />;
+}

--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 	theme?: string;
 }
 
-export default function Chart({ option, style, settings, show = true, loading, theme }: Props): JSX.Element | null {
+export default function Chart({ option, style, settings = { notMerge: true }, show = true, loading, theme }: Props): JSX.Element | null {
 	const ref = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Badge } from "./badge";
+export { default as Chart } from "./chart";
 export { StorageProvider } from "./context/storage";
 export { default as Field } from "./field";
 export { default as Dialog } from "./floating/dialog";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./context.hooks";
 export * from "./document.hooks";
 export * from "./function.hooks";
+export * from "./window.hooks";

--- a/src/hooks/window.hooks.tsx
+++ b/src/hooks/window.hooks.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string) {
+	const [active, setActive] = useState(false);
+	useEffect(() => {
+		const mediaQuery = window.matchMedia(query);
+		setActive(mediaQuery.matches);
+		mediaQuery.addEventListener("change", (evt) => setActive(evt.matches));
+	}, [query]);
+	return active;
+}
+
+export const useDark = () => useMediaQuery("(prefers-color-scheme: dark)");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,16 @@
 import { routes } from "@generouted/react-router";
+import { registerTheme } from "echarts";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { StorageProvider } from "./components";
 import "./index.css";
+
+const light = await import("$/assets/charts/light.json");
+const dark = await import("$/assets/charts/dark.json");
+
+registerTheme("dark", { ...dark.default });
+registerTheme("light", { ...light.default });
 
 const root = document.getElementById("root")!;
 

--- a/src/pages/[key]/index.tsx
+++ b/src/pages/[key]/index.tsx
@@ -44,7 +44,7 @@ export default function Overview() {
 							)}
 						</div>
 					)}
-					<Templates.Stub />
+					<Templates.Charts id={key} />
 				</Fragment>
 			) : (
 				"This dataset is not available."

--- a/src/templates/charts/helpers.tsx
+++ b/src/templates/charts/helpers.tsx
@@ -49,7 +49,7 @@ export const base = {
 		return {
 			...template,
 			...options,
-			xAxis: { type: "category", data: titles, axisTick: { show: false }, axisLabel: { show: false } },
+			xAxis: { type: "category", axisTick: { show: false }, axisLabel: { show: false }, data: titles },
 			series: difficulties.map((difficulty) => {
 				const values = data.filter((x) => x.difficulty === difficulty && transformer(x) !== undefined);
 				return {
@@ -69,27 +69,22 @@ export const base = {
 			const date = new Date(transformer(x));
 			return { hours: date.getHours(), day: date.getDay() };
 		});
+		const totals = cells.map((cell) => {
+			const values = data.filter((x) => {
+				const date = new Date(transformer(x));
+				return date.getDay() === cell.day && date.getHours() === cell.hours;
+			});
+			return values.length;
+		});
 		return {
 			...template,
 			...options,
 			xAxis: { type: "category", data: ["12 AM", "1 AM", "2 AM", "3 AM", "4 AM", "5 AM", "6 AM", "7 AM", "8 AM", "9 AM", "10 AM", "11 AM", "12 PM", "1 PM", "2 PM", "3 PM", "4 PM", "5 PM", "6 PM", "7 PM", "8 PM", "9 PM", "10 PM", "11 PM"] },
 			yAxis: { type: "category", data: ["Saturday", "Friday", "Thursday", "Wednesday", "Tuesday", "Monday", "Sunday"] },
-			visualMap: {
-				min: 0,
-				max: 500,
-				calculable: true,
-				orient: "horizontal",
-				left: "center",
-			},
+			visualMap: { min: 0, max: Math.max(...totals), calculable: true, orient: "horizontal", left: "center" },
 			series: {
 				type: "heatmap",
-				data: cells.map((cell) => {
-					const values = data.filter((x) => {
-						const date = new Date(transformer(x));
-						return date.getDay() === cell.day && date.getHours() === cell.hours;
-					});
-					return [cell.hours, cell.day, values.length];
-				}),
+				data: cells.map((cell, i) => [cell.hours, cell.day, totals[i]]),
 			},
 		};
 	},

--- a/src/templates/charts/helpers.tsx
+++ b/src/templates/charts/helpers.tsx
@@ -1,0 +1,72 @@
+import { flex, hstack, vstack } from "$/styles/patterns";
+import { IData, IDataset } from "$/types";
+import { predicates } from "$/utils";
+import { EChartsOption } from "echarts";
+
+export interface ChartProps {
+	id: string;
+	show?: boolean;
+	theme?: string;
+	height?: number;
+}
+
+type Chart = (dataset: IDataset<IData[]>, transformer: (data: IData) => string | number | Date, options?: EChartsOption, filter?: (data: IData) => boolean) => EChartsOption;
+
+const template: EChartsOption = {
+	animation: false,
+	tooltip: {},
+	legend: {
+		orient: "horizontal",
+		bottom: 0,
+	},
+};
+
+export const base = {
+	pie: (dataset, transformer, options, filter = () => true) => {
+		const data = dataset.data.filter((x) => filter(x));
+		const series = dataset.data.map(transformer).filter(predicates.unique);
+		return {
+			...template,
+			...options,
+			title: { ...template.title, ...options?.title },
+			legend: { show: false },
+			series: {
+				type: "pie",
+				data: series.map((serie) => {
+					const values = data.filter((x) => transformer(x) === serie && transformer(x) !== undefined);
+					return {
+						value: values.length,
+						name: serie.toString(),
+					};
+				}),
+			},
+		};
+	},
+	level: (dataset, transformer, options, filter = () => true) => {
+		const data = dataset.data.filter((x) => filter(x) && transformer(x) !== undefined);
+		const difficulties = dataset.data.map((x) => x.difficulty).filter(predicates.unique);
+		const titles = data.map((x) => x.title ?? x.id).filter(predicates.unique);
+		return {
+			...template,
+			...options,
+			xAxis: { type: "category", data: titles, axisTick: { show: false }, axisLabel: { show: false } },
+			series: difficulties.map((difficulty) => {
+				const values = data.filter((x) => x.difficulty === difficulty && transformer(x) !== undefined);
+				return {
+					type: "scatter",
+					name: difficulty,
+					data: values.map((x) => [titles.indexOf(x.title ?? x.id), transformer(x)]),
+					markLine: {
+						data: [{ type: "average", name: "Average" }],
+					},
+				};
+			}),
+		};
+	},
+} satisfies Record<string, Chart>;
+
+export const styles = {
+	wrapper: flex({ margin: 4, width: "full", direction: "column", gap: 4 }),
+	column: vstack(),
+	row: hstack(),
+};

--- a/src/templates/charts/helpers.tsx
+++ b/src/templates/charts/helpers.tsx
@@ -63,6 +63,36 @@ export const base = {
 			}),
 		};
 	},
+	time: (dataset, transformer, options, filter = () => true) => {
+		const data = dataset.data.filter((x) => filter(x) && transformer(x) !== undefined);
+		const cells = data.map((x) => {
+			const date = new Date(transformer(x));
+			return { hours: date.getHours(), day: date.getDay() };
+		});
+		return {
+			...template,
+			...options,
+			xAxis: { type: "category", data: ["12 AM", "1 AM", "2 AM", "3 AM", "4 AM", "5 AM", "6 AM", "7 AM", "8 AM", "9 AM", "10 AM", "11 AM", "12 PM", "1 PM", "2 PM", "3 PM", "4 PM", "5 PM", "6 PM", "7 PM", "8 PM", "9 PM", "10 PM", "11 PM"] },
+			yAxis: { type: "category", data: ["Saturday", "Friday", "Thursday", "Wednesday", "Tuesday", "Monday", "Sunday"] },
+			visualMap: {
+				min: 0,
+				max: 500,
+				calculable: true,
+				orient: "horizontal",
+				left: "center",
+			},
+			series: {
+				type: "heatmap",
+				data: cells.map((cell) => {
+					const values = data.filter((x) => {
+						const date = new Date(transformer(x));
+						return date.getDay() === cell.day && date.getHours() === cell.hours;
+					});
+					return [cell.hours, cell.day, values.length];
+				}),
+			},
+		};
+	},
 } satisfies Record<string, Chart>;
 
 export const styles = {

--- a/src/templates/charts/index.tsx
+++ b/src/templates/charts/index.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { styles } from "./helpers";
 import LevelCharts from "./level";
 import PieCharts from "./pie";
+import TimeCharts from "./time";
 
 interface Props {
 	id: string;
@@ -17,6 +18,7 @@ export default function Charts({ id }: Props) {
 			<div className={styles.wrapper}>
 				<PieCharts id={id} show={show} theme={dark ? "dark" : "light"} height={200} />
 				<LevelCharts id={id} show={show} theme={dark ? "dark" : "light"} height={300} />
+				<TimeCharts id={id} show={show} theme={dark ? "dark" : "light"} height={300} />
 			</div>
 		</details>
 	);

--- a/src/templates/charts/index.tsx
+++ b/src/templates/charts/index.tsx
@@ -1,0 +1,23 @@
+import { useDark } from "$/hooks";
+import { useState } from "react";
+import { styles } from "./helpers";
+import LevelCharts from "./level";
+import PieCharts from "./pie";
+
+interface Props {
+	id: string;
+}
+
+export default function Charts({ id }: Props) {
+	const dark = useDark();
+	const [show, setShow] = useState(false);
+	return (
+		<details open={show} onToggle={(e) => setShow(e.currentTarget.open)}>
+			<summary>Charts</summary>
+			<div className={styles.wrapper}>
+				<PieCharts id={id} show={show} theme={dark ? "dark" : "light"} height={200} />
+				<LevelCharts id={id} show={show} theme={dark ? "dark" : "light"} height={300} />
+			</div>
+		</details>
+	);
+}

--- a/src/templates/charts/level.tsx
+++ b/src/templates/charts/level.tsx
@@ -1,0 +1,53 @@
+import { Chart, Icon } from "$/components";
+import { calc } from "$/helpers";
+import { useDataset } from "$/hooks";
+import { IData, schemas } from "$/types";
+import { predicates } from "$/utils";
+import { useState } from "react";
+import { ChartProps, base, styles } from "./helpers";
+
+export default function LevelCharts({ id, show, theme, height }: ChartProps) {
+	const { state } = useDataset(id);
+	const [idx, setIdx] = useState(0);
+	const [pack, setPack] = useState("All");
+	const [characteristic, setCharacteristic] = useState("Standard");
+
+	const filter = (x: IData) => {
+		const withPack = pack !== "All" ? x.pack === pack : true;
+		return withPack && x.characteristic === characteristic;
+	};
+
+	const charts = [
+		base.level(state!, (x) => calc.nps(x)!.toFixed(2), { title: { text: "Level Distribution", subtext: "by NPS" }, yAxis: { min: 0 } }, filter), //
+		base.level(state!, (x) => x.jumpSpeed!, { title: { text: "Level Distribution", subtext: "by Jump Speed" }, yAxis: { min: 10 } }, filter),
+		base.level(state!, (x) => calc.jd(x)!.toFixed(3)!, { title: { text: "Level Distribution", subtext: "by Jump Distance" }, yAxis: { min: 10 } }, filter),
+	];
+	const packs = Object.values(state!.data.map((x) => x.pack).filter((x, i, a) => !!x && predicates.unique(x, i, a)));
+
+	if (!show) return null;
+	return (
+		<div className={styles.column}>
+			<Chart style={{ height }} theme={theme} option={charts[idx]}></Chart>
+			<div className={styles.row}>
+				<select disabled={pack === "All" && packs.length < 2} value={pack} onChange={(e) => setPack(e.target.value)}>
+					{["All", ...packs, pack].filter(predicates.unique).map((x) => (
+						<option key={x}>{x}</option>
+					))}
+				</select>
+				<select value={characteristic} onChange={(e) => setCharacteristic(e.target.value)}>
+					{Object.values(schemas.characteristic.Values).map((x) => (
+						<option key={x}>{x}</option>
+					))}
+				</select>
+			</div>
+			<div className={styles.row}>
+				<button disabled={idx === 0} onClick={() => setIdx((x) => x - 1)}>
+					<Icon className="fa-solid fa-arrow-left" />
+				</button>
+				<button disabled={idx === charts.length - 1} onClick={() => setIdx((x) => x + 1)}>
+					<Icon className="fa-solid fa-arrow-right" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/templates/charts/pie.tsx
+++ b/src/templates/charts/pie.tsx
@@ -1,0 +1,14 @@
+import { Chart } from "$/components";
+import { useDataset } from "$/hooks";
+import { ChartProps, base, styles } from "./helpers";
+
+export default function PieCharts({ id, show, theme, height }: ChartProps) {
+	const { state } = useDataset(id);
+	if (!show) return null;
+	return (
+		<div className={styles.row}>
+			<Chart style={{ height }} theme={theme} option={base.pie(state!, (x) => x.characteristic, {})} />
+			<Chart style={{ height }} theme={theme} option={base.pie(state!, (x) => x.difficulty, {})} />
+		</div>
+	);
+}

--- a/src/templates/charts/time.tsx
+++ b/src/templates/charts/time.tsx
@@ -1,0 +1,13 @@
+import { Chart } from "$/components";
+import { useDataset } from "$/hooks";
+import { ChartProps, base, styles } from "./helpers";
+
+export default function TimeCharts({ id, show, theme, height }: ChartProps) {
+	const { state } = useDataset(id);
+	if (!show) return null;
+	return (
+		<div className={styles.row}>
+			<Chart style={{ height }} theme={theme} option={base.time(state!, (x) => x.released!, { title: { text: "Release Dates", subtext: "by Time of Day" } })}></Chart>
+		</div>
+	);
+}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,8 +1,9 @@
 import { default as Actions } from "./actions";
+import { default as Charts } from "./charts";
 import { default as Content } from "./content";
 import { default as Icons } from "./icons";
 import { default as Profile } from "./profile";
 import { default as Stub } from "./stub";
 import { default as Table } from "./table";
 
-export default { Content, Actions, Table, Icons, Profile, Stub };
+export default { Actions, Charts, Content, Icons, Profile, Stub, Table };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,6 +3246,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.61.0
     "@typescript-eslint/parser": ^5.61.0
     "@vitejs/plugin-react": ^4.0.1
+    echarts: ^5.4.3
     eslint: ^8.44.0
     eslint-plugin-react-hooks: ^4.6.0
     eslint-plugin-react-refresh: ^0.4.1
@@ -3838,6 +3839,16 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 7d00d7cd8e49b9afa762a813faac332dee781932d6f2c848dc348939c4253f1d4564341b7af1d041853bc3f32c2ef141b58e0a4d9862c17a7f08f68df1e0f1ed
+  languageName: node
+  linkType: hard
+
+"echarts@npm:^5.4.3":
+  version: 5.4.3
+  resolution: "echarts@npm:5.4.3"
+  dependencies:
+    tslib: 2.3.0
+    zrender: 5.4.4
+  checksum: f4f69becf1cf8f546f9488ffa3bffaa971dcfbd49f5d635f288cbc8c5177839154bd6c325d6ed72c2b822c89c9bba4947ac73400614fd23c6f2f7ace3c939132
   languageName: node
   linkType: hard
 
@@ -8014,6 +8025,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.3.0":
+  version: 2.3.0
+  resolution: "tslib@npm:2.3.0"
+  checksum: 8869694c26e4a7b56d449662fd54a4f9ba872c889d991202c74462bd99f10e61d5bd63199566c4284c0f742277736292a969642cc7b590f98727a7cae9529122
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
@@ -8761,6 +8779,15 @@ __metadata:
   version: 3.21.4
   resolution: "zod@npm:3.21.4"
   checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
+  languageName: node
+  linkType: hard
+
+"zrender@npm:5.4.4":
+  version: 5.4.4
+  resolution: "zrender@npm:5.4.4"
+  dependencies:
+    tslib: 2.3.0
+  checksum: 4b317346af8eca38e62ba029239c3a13e97eac4fa15b3ddadbae23442d8b373f0e937c255dee8080d6bb2fc79c9da54f1106415586ed8942bd8bc684b3890ea9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
All of the charts from the original spreadsheet have been reintroduced on the **Overview** page, along with some additional charts that were originally featured in the _Custom Map Stats_ spreadsheet that ended up being scrapped from the old tracker.

## Preview
![charts](https://github.com/officialMECH/bs-analysis/assets/28495960/7d2893c1-5048-4c71-8956-df979377db36)

## Notes
- [Apache ECharts](https://echarts.apache.org/en/index.html) was used as the primary library for implementation, as it offers a vast array of chart types, interactivity, and performance considerations. This should give us a lot more agency for how we can better visualize data moving forward.
- Charts are hidden by default for performance reasons when loading larger datasets (most noticeable with OST/DLC).