### PR TITLE
Maintenance (2024-06-04)

### DIFF
--- a/scripts/merge.js
+++ b/scripts/merge.js
@@ -15,7 +15,7 @@ function sort([_a, a], [_b, b]) {
 }
 
 const dataset = files.reduce((original, entry) => {
-	if (entry.name === "config.json") return original;
+	if (entry.name.endsWith("config.json")) return original;
 	const path = join(directory, entry.name);
 	const raw = JSON.parse(readFileSync(path, { encoding: "utf-8" }));
 	return [original, raw.data].reduce((record, current) => {


### PR DESCRIPTION
- Any values in local storage that are non-serializable will now be properly ignored by the app, which should no longer break the app for cross-site contexts.
- The `merge` script will now treat all files that end with `config.json` as script configuration files, which should give you more flexibility for how you choose to arrange and organize your dataset files.